### PR TITLE
Display the kontrol report in a new vscode tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "kaas-vscode",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kaas-vscode",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "git-url-parse": "^16.1.0",
         "openapi-fetch": "^0.14.0",
+        "parse-duration": "^2.1.4",
         "smol-toml": "^1.3.4"
       },
       "devDependencies": {
@@ -3498,6 +3499,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-duration": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-2.1.4.tgz",
+      "integrity": "sha512-b98m6MsCh+akxfyoz9w9dt0AlH2dfYLOBss5SdDsr9pkhKNvkWBXU/r8A4ahmIGByBOLV2+4YwfCuFxbDDaGyg=="
     },
     "node_modules/parse-path": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "K as a Service",
   "description": "K as a Service (KaaS) extension for VS Code providing K framework integration and tooling",
   "license": "BSD-3-Clause",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "publisher": "runtimeverification",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
   "dependencies": {
     "git-url-parse": "^16.1.0",
     "openapi-fetch": "^0.14.0",
+    "parse-duration": "^2.1.4",
     "smol-toml": "^1.3.4"
   },
   "husky": {

--- a/src/kaas-api.ts
+++ b/src/kaas-api.ts
@@ -2198,6 +2198,8 @@ export interface components {
       avatar: string | null;
     };
     IJob: {
+      testsuite: never[];
+      $: any;
       /**
        * @description The unique job ID.
        * @example abcdef1234567890abcdef1234567890abcdef12

--- a/src/kaas_jobs.ts
+++ b/src/kaas_jobs.ts
@@ -58,6 +58,26 @@ export async function getJobStatusByJobId(
   return job.data;
 }
 
+export async function getJobReportByJobId(
+  client: Client<paths>,
+  jobId: string
+): Promise<components['schemas']['IJob']> {
+  const job = await client.GET('/api/jobs/{jobId}/json-report', {
+    params: {
+      path: {
+        jobId,
+      },
+    },
+  });
+  if (job.response.status !== 200) {
+    throw new Error(`Job with ID ${jobId} not found`);
+  }
+  if (job.data === undefined) {
+    throw new Error(`Job with ID ${jobId} returned no data`);
+  }
+  return job.data.testsuites;
+}
+
 export async function pollForJobStatus(
   client: Client<paths>,
   testController: vscode.TestController,
@@ -74,6 +94,21 @@ export async function pollForJobStatus(
         testRun.appendOutput(
           `Run completed successfully. See details here: ${jobUri(jobDetails).toString()}`
         );
+        if (jobDetails.children && jobDetails.children.length > 0) {
+          for (const childJob of jobDetails.children) {
+            const report = await getJobReportByJobId(client, childJob.id);
+            if (report) {
+              const panel = vscode.window.createWebviewPanel(
+                'report', // Identifies the type of the webview. Used internally
+                'Report', // Title of the panel displayed to the user
+                vscode.ViewColumn.One, // Editor column to show the new webview panel in
+                {} // Webview options
+              );
+
+              panel.webview.html = getReportContentHtml(report);
+            }
+          }
+        }
         testRun.passed(test, jobDetails.duration * 1000);
         testRun.end();
         break;
@@ -226,4 +261,138 @@ export function jobCacheUri(job: components['schemas']['IJob']): vscode.Uri | un
   } else {
     return undefined; // No cache found
   }
+}
+
+function getReportContentHtml(report: components['schemas']['IJob']): string {
+  // Extract your dynamic values from the report object
+  const totalTests = report.$.tests ?? 0;
+  const totalErrors = report.$.errors ?? 0;
+  const totalFailures = report.$.failures ?? 0;
+  const passingTests = totalTests - totalErrors - totalFailures;
+
+  const passRate = totalTests > 0 ? (passingTests / totalTests) * 100 : 0;
+  const duration = report.$.time ? formatDuration(Number(report.$.time) * 1000) : 'N/A';
+  const timestamp = report.$.timestamp ?? '';
+
+  const verificationSummary = `<h1>Verification Summary</h1>
+  <div class="summary">
+    <div>
+      <div>Total Tests</div>
+      <div><b>${totalTests}</b></div>
+    </div>
+    <div>
+      <div style="color: green;">Passed</div>
+      <div style="color: green;"><b>${passingTests}</b></div>
+    </div>
+    <div>
+      <div style="color: red;">Failures</div>
+      <div style="color: red;"><b>${totalFailures}</b></div>
+    </div>
+    <div>
+      <div style="color: orange;">Errors</div>
+      <div style="color: orange;"><b>${totalErrors}</b></div>
+    </div>
+  </div>
+  <div style="margin-top:2em;">
+    <div>Pass Rate: <b>${passRate.toFixed(2)}%</b></div>
+    <div class="progress-bar">
+      <div class="progress" style="width: ${passRate}%;"></div>
+    </div>
+  </div>
+  <div style="margin-top:2em;">
+    <div>Duration: <b>${duration}</b></div>
+    <div>Timestamp: <b>${timestamp}</b></div>
+  </div>`;
+
+  // Loop over test suites and build HTML for each
+  let suitesHtml = `<h1>Test Suites</h1>`;
+  const testSuites = report.testsuite ?? [];
+  for (const suite of testSuites) {
+    const suiteTests = report.$.tests ?? 0;
+    const suiteErrors = report.$.errors ?? 0;
+    const suiteFailures = report.$.failures ?? 0;
+    const suitepassingTests = suiteTests - suiteErrors - suiteFailures;
+    suitesHtml += `
+    <div class="suite">
+      <h2>${suite.$.name}</h2>
+      <hr>
+      <div class="suite-info">
+        <b>Passing:</b> <span style="color:green;">${suitepassingTests}</span> &nbsp; 
+        <b>Failures:</b> <span style="color:red;">${suiteFailures}</span> &nbsp; 
+        <b>Errors:</b> <span style="color:orange;">${suiteErrors}</span> &nbsp; 
+        <b>Time:</b> ${formatDuration(Number(suite.$.time) * 1000)} seconds
+      </div>
+      <hr>
+      <table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em; width:100%;">
+        <thead>
+          <tr>
+            <th>Test Name</th>
+            <th>Status</th>
+            <th>Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${(suite.testcase ?? [])
+            .map(
+              (test: any) => `
+            <tr>
+              <td>${test.$.name}</td>
+              <td>
+                ${test.failure ? '<span style="color:red;">Failed</span>' : test.error ? '<span style="color:orange;">Passed</span>' : '<span style="color:green;">Passed</span>'}
+              </td>
+              <td>
+                ${test.$.time ? `${formatDuration(Number(test.$.time) * 1000)}` : 'N/A'}
+              </td>
+            </tr>
+          `
+            )
+            .join('')}
+        </tbody>
+      </table>
+    </div>
+  `;
+  }
+
+  // Build the HTML string with template literals
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Formal Verification Report</title>
+    <style>
+      body { font-family: sans-serif; margin: 2em; }
+      .summary { display: flex; gap: 2em; }
+      .summary div { padding: 1em; border-radius: 8px; }
+      .progress-bar { background: #eee; border-radius: 4px; height: 16px; width: 100%; }
+      .progress { background: #4caf50; height: 100%; border-radius: 4px; }
+      .suite-info span { margin-right: 3.0em; } /* Add this line */
+    </style>
+</head>
+<body>
+    ${verificationSummary}
+    ${suitesHtml}
+</body>
+</html>
+`;
+}
+
+// Helper function to format milliseconds into human-readable duration
+function formatDuration(ms: number): string {
+  if (isNaN(ms)) {
+    return 'N/A';
+  }
+  const seconds = Math.floor((ms / 1000) % 60);
+  const minutes = Math.floor((ms / (1000 * 60)) % 60);
+  const hours = Math.floor((ms / (1000 * 60 * 60)) % 24);
+  const parts = [];
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0) {
+    parts.push(`${minutes}m`);
+  }
+  parts.push(`${seconds}s`);
+  return parts.join(' ');
 }


### PR DESCRIPTION
Once the tests finish, the report is displayed in a new VS Code tab. This way, the user does not need to go outside of VS Code to inspect the results of the Kaas run. 
Following is a screenshot of the report presentation in vscode:
<img width="1128" height="632" alt="Screenshot from 2025-07-29 14-18-01" src="https://github.com/user-attachments/assets/aa3f5972-1778-4109-8d77-22136e1d8274" />
