### PR TITLE
[WIP] Embed report and cache view from kaas website directly in the vscode extension

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,12 +19,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          corepack enable
-          yarn install
+          npm install
 
       - name: Build
         run: |
-          yarn build
+          npm run build
 
       - name: Get current package version
         id: package_version

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,7 @@ export async function activate(context: vscode.ExtensionContext) {
   ): vscode.WebviewPanel {
     const baseUrl = getKaasBaseUrl();
     const apiKey = vscode.workspace.getConfiguration('kaas-vscode').get<string>('apiKey');
-    const authUrl = `${baseUrl}/api/api-token-auth?api-token=${apiKey}&redirect=${encodeURIComponent(url + '?embed=true')}`;
+    const authUrl = `${url}?api-token=${apiKey}`;
 
     console.log(`authUrl: `, authUrl);
 
@@ -141,7 +141,7 @@ export async function activate(context: vscode.ExtensionContext) {
           </style>
       </head>
       <body>
-          <iframe src="${authUrl}" sandbox="allow-scripts allow-same-origin allow-forms allow-top-navigation"></iframe>
+          <iframe src="${authUrl}" sandbox="allow-scripts allow-same-origin allow-forms allow-top-navigation allow-popups allow-popups-to-escape-sandbox"></iframe>
       </body>
       </html>
     `;


### PR DESCRIPTION
Blocked by https://github.com/runtimeverification/kaas/pull/1384

For testing and before we merge https://github.com/runtimeverification/kaas/pull/1384, please set `kaas-vscode.baseUrl` to `https://pr-1384.kaas-sandbox.runtimeverification.com/`, then set `kaas-vscode.apiKey` to use the one generated from https://pr-1384.kaas-sandbox.runtimeverification.com/